### PR TITLE
Fix URL for module support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/RenaultAI/goStrongswanVici
+module github.com/bronze1man/goStrongswanVici
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
go mod vendor errors when trying to vendor this module. This should fix it up.